### PR TITLE
Trivial fix for HDF5 1.12 use H5_USE_110_API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BSLZ4_BUILD_DIR = ./bslz4/build
 BSLZ4_INC_DIR = $(BSLZ4_SRC_DIR)
 
 CC=h5cc
-CFLAGS=-Wall -g -O2 -fpic -I$(INC_DIR) -I$(BSLZ4_INC_DIR) -std=c89 -shlib
+CFLAGS=-DH5_USE_110_API -Wall -g -O2 -fpic -I$(INC_DIR) -I$(BSLZ4_INC_DIR) -std=c89 -shlib
 
 .PHONY: plugin
 plugin: $(BUILD_DIR)/durin-plugin.so


### PR DESCRIPTION
Fixes #18 - compile against 1.10 API (may need to do more work to make sure this
does what we actually want)