### PR TITLE
Three modifications: Handling of overloaded pixels, signed data arrays and image number offsets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,19 @@ BSLZ4_BUILD_DIR = ./bslz4/build
 BSLZ4_INC_DIR = $(BSLZ4_SRC_DIR)
 
 CC=h5cc
-CFLAGS=-DH5_USE_110_API -Wall -g -O2 -fpic -I$(INC_DIR) -I$(BSLZ4_INC_DIR) -std=c99 -shlib
+# -std=gnu99 provides for strtok_r
+CFLAGS=-DH5_USE_110_API -Wall -g -O2 -fpic -I$(INC_DIR) -I$(BSLZ4_INC_DIR) -std=gnu99 -shlib
+
+# include https://github.com/kiyo-masui/bitshuffle (to handle
+# e.g. bitshuffle compressed pixel_masks)
+use_BITSHUFFLE =
+ifeq ($(use_BITSHUFFLE),)
+else
+BITSHUFFLE_SRC_DIR = ../bitshuffle-master/src/
+BITSHUFFLE_INC_DIR = ../bitshuffle-master/src/
+BITSHUFFLE_OBJS    = $(BUILD_DIR)/bshuf_h5filter.o
+CFLAGS += -DUSE_BITSHUFFLE -I$(BITSHUFFLE_INC_DIR)
+endif
 
 .PHONY: plugin
 plugin: $(BUILD_DIR)/durin-plugin.so
@@ -26,6 +38,10 @@ $(BUILD_DIR)/test_plugin: $(TEST_DIR)/generic_data_plugin.f90 $(TEST_DIR)/test_g
 	mkdir -p $(BUILD_DIR)
 	gfortran -O -g -fopenmp -ldl $(TEST_DIR)/generic_data_plugin.f90 $(TEST_DIR)/test_generic_host.f90 -o $@ -J$(BUILD_DIR)
 
+$(BUILD_DIR)/bshuf_h5filter.o: $(BITSHUFFLE_SRC_DIR)/bshuf_h5filter.c
+	mkdir -p $(BUILD_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -39,7 +55,7 @@ $(BSLZ4_BUILD_DIR)/bitshuffle_core.o $(BSLZ4_BUILD_DIR)/iochain.o
 	mkdir -p $(BUILD_DIR)
 	ar rcs $@ $^
 
-$(BUILD_DIR)/durin-plugin.so: $(BUILD_DIR)/plugin.o $(BUILD_DIR)/file.o $(BUILD_DIR)/err.o $(BUILD_DIR)/filters.o \
+$(BUILD_DIR)/durin-plugin.so: $(BUILD_DIR)/plugin.o $(BUILD_DIR)/file.o $(BUILD_DIR)/err.o $(BUILD_DIR)/filters.o $(BITSHUFFLE_OBJS) \
 $(BUILD_DIR)/bslz4.a
 	mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) -shared -noshlib $^ -o $(BUILD_DIR)/durin-plugin.so

--- a/src/file.c
+++ b/src/file.c
@@ -582,11 +582,15 @@ int get_dectris_eiger_pixel_mask(const struct ds_desc_t *desc, int *buffer) {
     size_t          nelmts = 1;
     unsigned int    values_out[1] = {99};
     char            filter_name[80];
-    filter_id = H5Pget_filter(dcpl, (unsigned) 0, &flags, &nelmts, values_out, sizeof(filter_name), filter_name, NULL);
-    if (filter_id>=0) {
-      fprintf(stderr," filter name =\"%s\"\n",filter_name);
+    for ( int i_filt = 0; i_filt < n_filters; i_filt++) {
+      filter_id = H5Pget_filter(dcpl, i_filt, &flags, &nelmts, values_out, sizeof(filter_name), filter_name, NULL);
+      if (filter_id>=0) {
+        fprintf(stderr," filter #%d name =\"%s\"\n",(i_filt+1),filter_name);
+      }
     }
   }
+
+  int i0 = H5Zfilter_avail(BS_H5_FILTER_ID);
 
   err = H5Dread(ds_id, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer);
   if (err < 0) {
@@ -598,7 +602,7 @@ int get_dectris_eiger_pixel_mask(const struct ds_desc_t *desc, int *buffer) {
     }
   }
 
-  if (H5Zfilter_avail(BS_H5_FILTER_ID)) {
+  if (!i0 && H5Zfilter_avail(BS_H5_FILTER_ID)) {
     fprintf(stderr," bitshuffle filter is available now since H5Dread (of pixel-mask) triggered loading of the filter.\n");
   }
 

--- a/src/file.c
+++ b/src/file.c
@@ -104,7 +104,13 @@ int get_nxs_dataset_dims(struct ds_desc_t *desc) {
     ERROR_JUMP(-1, close_space, "Error getting dataset dimensions");
   }
 
-  desc->data_width = width;
+  if ( H5Tequal(t_id,H5T_NATIVE_CHAR)>0 || H5Tequal(t_id,H5T_NATIVE_INT)>0 || H5Tequal(t_id,H5T_NATIVE_SHORT)>0 || H5Tequal(t_id,H5T_NATIVE_LONG)>0 || H5Tequal(t_id,H5T_NATIVE_LLONG)>0 ) {
+    // signed
+    desc->data_width = -width;
+  } else {
+    // unsigned
+    desc->data_width =  width;
+  }
 
 close_space:
   H5Sclose(s_id);
@@ -233,7 +239,7 @@ int get_frame_from_chunk(const struct ds_desc_t *desc, const char *ds_name,
 
   if (o_eiger_desc->bs_applied) {
     if (bslz4_decompress(o_eiger_desc->bs_params, c_bytes, c_buffer,
-                         desc->data_width * frame_size[1] * frame_size[2],
+                         abs(desc->data_width) * frame_size[1] * frame_size[2],
                          buffer) < 0) {
       char message[128];
       sprintf(message,
@@ -350,6 +356,10 @@ int get_dectris_eiger_dataset_dims(struct ds_desc_t *desc) {
     data_width = H5Tget_size(t_id);
     if (data_width <= 0) {
       ERROR_JUMP(-1, close_space, "Unable to get type size");
+    }
+    if ( H5Tequal(t_id,H5T_NATIVE_CHAR)>0 || H5Tequal(t_id,H5T_NATIVE_INT)>0 || H5Tequal(t_id,H5T_NATIVE_SHORT)>0 || H5Tequal(t_id,H5T_NATIVE_LONG)>0 || H5Tequal(t_id,H5T_NATIVE_LLONG)>0 ) {
+      // signed
+      data_width = -data_width;
     }
 
     ndims = H5Sget_simple_extent_ndims(s_id);

--- a/src/file.c
+++ b/src/file.c
@@ -257,11 +257,12 @@ done:
 
 int get_nxs_frame(
 		const struct ds_desc_t *desc,
-		const int n,
+		const int nin,
 		void *buffer) {
 	/* detector data are the two inner most indices */
 	/* TODO: handle ndims > 3 and select appropriately */
 	int retval = 0;
+	int n = nin - desc->image_number_offset;
 	hsize_t frame_idx[3] = {n, 0, 0};
 	hsize_t frame_size[3] = {1, desc->dims[1], desc->dims[2]};
 	if (n < 0 || n >= desc->dims[0]) {
@@ -280,10 +281,11 @@ done:
 
 int get_dectris_eiger_frame(
 		const struct ds_desc_t *desc,
-		int n,
+		int nin,
 		void *buffer) {
 
 	int retval = 0;
+	int n = nin - desc->image_number_offset;
 	int block, frame_count, idx;
 	struct eiger_ds_desc_t *eiger_desc = (struct eiger_ds_desc_t*) desc;
 	char data_name[16] = {0};

--- a/src/file.c
+++ b/src/file.c
@@ -683,6 +683,9 @@ herr_t det_visit_callback(hid_t root_id, const char *name,
       ERROR_JUMP(-1, free_buffer, message);
     }
 
+    /* ensure the buffer is null terminated */
+    buffer[H5Tget_size(t_id)] = '\0';
+
     /* test for NXdata or NXdetector */
     {
       if      (strcmp("NXdata", buffer) == 0) {

--- a/src/file.h
+++ b/src/file.h
@@ -20,6 +20,7 @@ struct ds_desc_t {
   int (*get_pixel_mask)(const struct ds_desc_t *, int *);
   int (*get_data_frame)(const struct ds_desc_t *, const int, void *);
   void (*free_desc)(struct ds_desc_t *);
+  int i2i[]; // array to hold a translation from the image number requested by XDS and the actual position in the HDF5 file
 };
 
 struct nxs_ds_desc_t {

--- a/src/file.h
+++ b/src/file.h
@@ -17,6 +17,7 @@ struct ds_desc_t {
 	hid_t data_g_id;
 	hsize_t dims[3];
 	int data_width;
+        int image_number_offset;
 	int (*get_pixel_properties)(const struct ds_desc_t*, double*, double*);
 	int (*get_pixel_mask)(const struct ds_desc_t*, int*);
 	int (*get_data_frame)(const struct ds_desc_t*, const int, void*);

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -11,6 +11,10 @@
 #include "filters.h"
 #include "plugin.h"
 
+#ifdef USE_BITSHUFFLE
+#include "bshuf_h5filter.h"
+#endif
+
 /* XDS does not provide an error callback facility, so just write to stderr
    for now - generally regarded as poor practice */
 #define ERROR_OUTPUT stderr
@@ -285,6 +289,12 @@ void plugin_open(const char *filename, int info[1024], int *error_flag) {
   if (init_h5_error_handling() < 0) {
     ERROR_JUMP(-2, done, "Failed to configure HDF5 error handling");
   }
+
+#ifdef USE_BITSHUFFLE
+  if (bshuf_register_h5filter() < 0 ) {
+    ERROR_JUMP(-2, done, "Failed to register bitshuffle filter");
+  }
+#endif
 
   fill_info_array(info);
   file_id = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -218,6 +218,10 @@ void plugin_open(const char *filename, int info[1024], int *error_flag) {
   }
   retval = 0;
 
+#ifdef GPHL_COMPILE_DATE
+  fprintf(ERROR_OUTPUT, "\n XDS HDF5/Durin plugin %d.%d.%d (DLS, 2018-2023; GPhL, 2020-2024 - built %d)\n", info[1], info[2], info[3], GPHL_COMPILE_DATE);
+#endif
+
 done:
   *error_flag = retval;
   if (retval < 0) {

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -17,24 +17,41 @@
 /* mask bits loosely based on what Neggia does and what NeXus says should be
    done basically - anything in the low byte (& 0xFF) means "ignore this"
    Neggia uses the value -2 if bit 1, 2 or 3 are set */
-#define COPY_AND_MASK(in, out, size, mask)                                     \
+/* CV-GPhL-20210408: we want more control over the value non-masked
+   pixels should be set to. */
+#define COPY_AND_MASK(in, value, setValue, out, size, mask)                    \
   {                                                                            \
     int i;                                                                     \
-    if (mask) {                                                                \
-      for (i = 0; i < size; ++i) {                                             \
-        out[i] = in[i];                                                        \
-        if (mask[i] & 0xFF)                                                    \
-          out[i] = -1;                                                         \
-        if (mask[i] & 30)                                                      \
-          out[i] = -2;                                                         \
+    if (value!=0) {                                                            \
+      if (mask) {                                                              \
+        for (i = 0; i < size; ++i) {                                           \
+          out[i] = (in[i] == value) ? setValue : in[i];                        \
+          if (mask[i] & 0xFF)                                                  \
+            out[i] = -1;                                                       \
+          if (mask[i] & 30)                                                    \
+            out[i] = -2;                                                       \
+        }                                                                      \
+      } else {                                                                 \
+        for (i = 0; i < size; i++) {                                           \
+          out[i] = (in[i] == value) ? setValue : in[i];                        \
+        }                                                                      \
       }                                                                        \
     } else {                                                                   \
-      for (i = 0; i < size; i++) {                                             \
-        out[i] = in[i];                                                        \
+      if (mask) {                                                              \
+        for (i = 0; i < size; ++i) {                                           \
+          out[i] = in[i];                                                      \
+          if (mask[i] & 0xFF)                                                  \
+            out[i] = -1;                                                       \
+          if (mask[i] & 30)                                                    \
+            out[i] = -2;                                                       \
+        }                                                                      \
+      } else {                                                                 \
+        for (i = 0; i < size; i++) {                                           \
+          out[i] = in[i];                                                      \
+        }                                                                      \
       }                                                                        \
     }                                                                          \
   }
-
 #define APPLY_MASK(buffer, mask, size)                                         \
   {                                                                            \
     int i;                                                                     \
@@ -58,36 +75,97 @@ void fill_info_array(int info[1024]) {
   info[2] = VERSION_MINOR;
   info[3] = VERSION_PATCH;
   info[4] = VERSION_TIMESTAMP;
+  info[5] = 0; // image number offset
+  info[6] = -1; // marked pixels not already in pixel_mask: reset to this value
+
+  char *cenv;
+  cenv = getenv("DURIN_IMAGE_NUMBER_OFFSET");
+  if (cenv!=NULL) {
+    info[5] = atoi(cenv);
+  }
+  cenv = getenv("DURIN_RESET_UNMASKED_PIXEL");
+  if (cenv!=NULL) {
+    info[6] = atoi(cenv);
+  }
+
 }
 
-int convert_to_int_and_mask(void *in_buffer, int d_width, int *out_buffer,
+int convert_to_int_and_mask(void *in_buffer, int width, int setValue, int *out_buffer,
                             int length, int *mask) {
   /* transfer data to output buffer, performing data conversion as required */
   int retval = 0;
   /* TODO: decide how conversion of data should work */
   /* Should we sign extend? Neggia doesn't (casts from uint*), but may be more
    * intuitive */
-  if (d_width == sizeof(signed char)) {
-    signed char *in = in_buffer;
-    COPY_AND_MASK(in, out_buffer, length, mask);
-  } else if (d_width == sizeof(short)) {
-    short *in = in_buffer;
-    COPY_AND_MASK(in, out_buffer, length, mask);
-  } else if (d_width == sizeof(int)) {
-    int *in = in_buffer;
-    COPY_AND_MASK(in, out_buffer, length, mask);
-  } else if (d_width == sizeof(long int)) {
-    long int *in = in_buffer;
-    COPY_AND_MASK(in, out_buffer, length, mask);
-  } else if (d_width == sizeof(long long int)) {
-    long long int *in = in_buffer;
-    COPY_AND_MASK(in, out_buffer, length, mask);
-  } else {
-    char message[128];
-    sprintf(message, "Unsupported conversion of data width %d to %ld (int)",
-            d_width, sizeof(int));
-    ERROR_JUMP(-1, done, message);
+
+  int d_width = abs(width);
+
+  // CV-20210407
+  //   Dealing with a signed data array: no extra check for marker
+  //   value needed (since data can already take advantage of the
+  //   negative data range). It is unclear though why/when data would
+  //   come in as a signed array in the first place ...
+  if (width<0) {
+    if (d_width == sizeof(signed char)) {
+      // 8-bit
+      signed char *in = in_buffer;
+      COPY_AND_MASK(in, 0, setValue, out_buffer, length, mask);
+    } else if (d_width == sizeof(short)) {
+      // 16-bit
+      short *in = in_buffer;
+      COPY_AND_MASK(in, 0, setValue, out_buffer, length, mask);
+    } else if (d_width == sizeof(int)) {
+      // 16-bit
+      int *in = in_buffer;
+      COPY_AND_MASK(in, 0, setValue, out_buffer, length, mask);
+    } else if (d_width == sizeof(long int)) {
+      // 32-bit
+      long int *in = in_buffer;
+      COPY_AND_MASK(in, 0, setValue, out_buffer, length, mask);
+    } else if (d_width == sizeof(long long int)) {
+      // 64-bit
+      long long int *in = in_buffer;
+      COPY_AND_MASK(in, 0, setValue, out_buffer, length, mask);
+    } else {
+      char message[128];
+      sprintf(message, "Unsupported conversion of data width %d to %ld (int)",
+              d_width, sizeof(int));
+      ERROR_JUMP(-1, done, message);
+    }
   }
+  // CV-20210407
+  //   Dealing with an unsigned data array: extra check for marker
+  //   value required (to handle overloaded pixels correctly if wanted
+  //   - see also DURIN_RESET_UNMASKED_PIXEL environment variable).
+  else {
+    if (d_width == sizeof(unsigned char)) {
+      // 8-bit
+      unsigned char *in = in_buffer;
+      COPY_AND_MASK(in, UINT8_MAX, setValue, out_buffer, length, mask);
+    } else if (d_width == sizeof(unsigned short)) {
+      // 16-bit
+      unsigned short *in = in_buffer;
+      COPY_AND_MASK(in, UINT16_MAX, setValue, out_buffer, length, mask);
+    } else if (d_width == sizeof(unsigned int)) {
+      // 16-bit
+      unsigned int *in = in_buffer;
+      COPY_AND_MASK(in, UINT16_MAX, setValue, out_buffer, length, mask);
+    } else if (d_width == sizeof(unsigned long)) {
+      // 32-bit
+      unsigned long *in = in_buffer;
+      COPY_AND_MASK(in, UINT32_MAX, setValue, out_buffer, length, mask);
+    } else if (d_width == sizeof(unsigned long long)) {
+      // 64-bit
+      unsigned long long *in = in_buffer;
+      COPY_AND_MASK(in, UINT32_MAX, setValue, out_buffer, length, mask);
+    } else {
+      char message[128];
+      sprintf(message, "Unsupported conversion of data width %d to %ld (int)",
+              d_width, sizeof(int));
+      ERROR_JUMP(-1, done, message);
+    }
+  }
+
 done:
   return retval;
 }
@@ -124,12 +202,7 @@ void plugin_open(const char *filename, int info[1024], int *error_flag) {
     ERROR_JUMP(-4, done, "");
   }
 
-  data_desc->image_number_offset = 0;
-  char *cenv;
-  cenv = getenv("DURIN_IMAGE_NUMBER_OFFSET");
-  if (cenv!=NULL) {
-    data_desc->image_number_offset = atoi(cenv);
-  }
+  data_desc->image_number_offset = info[5];
 
   mask_buffer = malloc(data_desc->dims[1] * data_desc->dims[2] * sizeof(int));
   if (mask_buffer) {
@@ -172,7 +245,7 @@ void plugin_get_header(int *nx, int *ny, int *nbytes, float *qx, float *qy,
 
   *nx = data_desc->dims[2];
   *ny = data_desc->dims[1];
-  *nbytes = data_desc->data_width;
+  *nbytes = abs(data_desc->data_width);
   *number_of_frames = data_desc->dims[0];
   *qx = (float)x_pixel_size;
   *qy = (float)y_pixel_size;
@@ -193,10 +266,10 @@ void plugin_get_data(int *frame_number, int *nx, int *ny, int *data_array,
   fill_info_array(info);
 
   void *buffer = NULL;
-  if (sizeof(*data_array) == data_desc->data_width) {
+  if (sizeof(*data_array) == abs(data_desc->data_width)) {
     buffer = data_array;
   } else {
-    buffer = malloc(data_desc->data_width * frame_size_px);
+    buffer = malloc(abs(data_desc->data_width) * frame_size_px);
     if (!buffer) {
       ERROR_JUMP(-1, done, "Unable to allocate data buffer");
     }
@@ -209,7 +282,7 @@ void plugin_get_data(int *frame_number, int *nx, int *ny, int *data_array,
   }
 
   if (buffer != data_array) {
-    if (convert_to_int_and_mask(buffer, data_desc->data_width, data_array,
+    if (convert_to_int_and_mask(buffer, data_desc->data_width, info[6], data_array,
                                 frame_size_px, mask_buffer) < 0) {
       char message[64];
       sprintf(message, "Error converting data for frame %d", *frame_number);

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -125,6 +125,13 @@ void plugin_open(
 		ERROR_JUMP(-4, done, "");
 	}
 
+	data_desc->image_number_offset = 0;
+	char *cenv;
+	cenv = getenv("DURIN_IMAGE_NUMBER_OFFSET");
+	if (cenv!=NULL) {
+	  data_desc->image_number_offset = atoi(cenv);
+	}
+
 	mask_buffer = malloc(data_desc->dims[1] * data_desc->dims[2] * sizeof(int));
 	if (mask_buffer) {
 		retval = data_desc->get_pixel_mask(data_desc, mask_buffer);


### PR DESCRIPTION
Here are three changes/modifications:

1. Invalid pixels not present/marked in the pixel mask can be reset to an overload marker if environment variable DURIN_RESET_UNMASKED_PIXEL is defined
2. More explicit handling of (potentially) signed/unsigned data arrays
3. To allow for a distinction between a numerical image name and its ordinal within the data arrays: allow for environment variable DURIN_IMAGE_NUMBER_OFFSET to define the difference (so that we can fetch data for image "1001" when this is the first image of the data array)

Any comments appreciated ;-)