### PR TITLE
Prioritise virtual datset

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -837,27 +837,29 @@ int create_dataset_descriptor(struct ds_desc_t **desc,
   }
 
   /* determine where the data is stored and what strategy to use */
-  /* we select the "dectris-eiger" strategy if both are valid due to
-   * potential confusion with the sizes of a virtual dataset, possible failure
-   * opening if we're using an old library version, and the potential to use the
-   * optimised chunk read strategy
+  /* we select the "virtual-dataset" strategy if both are valid as the 
+   * virtual dataset is more likely to be the intended dataset, now that 
+   * multiple virtual datasets can be taken in a single collection (e.g.
+   * for multi-sample pins). In these cases, all of the images taken in the
+   * full collection are linked as data_######.h5 files with the virtual
+   * dataset mapping to the relevant images for the current sample.
    */
-  if (H5Lexists(visit_result->nxdetector, "data_000001", H5P_DEFAULT) > 0) {
-    ds_id = visit_result->nxdetector;
-    ds_prop_func = &get_dectris_eiger_dataset_dims;
-    frame_func = &get_dectris_eiger_frame;
-  } else if (H5Lexists(visit_result->nxdetector, "data", H5P_DEFAULT) > 0) {
+  if (H5Lexists(visit_result->nxdetector, "data", H5P_DEFAULT) > 0) {
     ds_id = visit_result->nxdetector;
     ds_prop_func = &get_nxs_dataset_dims;
     frame_func = &get_nxs_frame;
-  } else if (H5Lexists(visit_result->nxdata, "data_000001", H5P_DEFAULT) > 0) {
-    ds_id = visit_result->nxdata;
+  } else if (H5Lexists(visit_result->nxdetector, "data_000001", H5P_DEFAULT) > 0) {
+    ds_id = visit_result->nxdetector;
     ds_prop_func = &get_dectris_eiger_dataset_dims;
     frame_func = &get_dectris_eiger_frame;
   } else if (H5Lexists(visit_result->nxdata, "data", H5P_DEFAULT) > 0) {
     ds_id = visit_result->nxdata;
     ds_prop_func = &get_nxs_dataset_dims;
     frame_func = &get_nxs_frame;
+  } else if (H5Lexists(visit_result->nxdata, "data_000001", H5P_DEFAULT) > 0) {
+    ds_id = visit_result->nxdata;
+    ds_prop_func = &get_dectris_eiger_dataset_dims;
+    frame_func = &get_dectris_eiger_frame;
   } else {
     ERROR_JUMP(-1, done, "Could not locate detector dataset");
   }

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -5,10 +5,17 @@
 
 #include <hdf5.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "file.h"
 #include "filters.h"
 #include "plugin.h"
+
+static size_t bslz4_h5z_filter(unsigned int flags, size_t cd_nelmts,
+                               const unsigned int cd_values[],
+                               size_t nbytes, size_t *buf_size,
+                               void **buf);
+static int register_bitshuffle_filter(void);
 
 /* XDS does not provide an error callback facility, so just write to stderr
    for now - generally regarded as poor practice */
@@ -96,6 +103,17 @@ done:
 extern "C" {
 #endif
 
+static const H5Z_class2_t bslz4_h5z_class = {
+    H5Z_CLASS_T_VERS,
+    BS_H5_FILTER_ID,
+    0,
+    1,
+    "bitshuffle",
+    NULL,
+    NULL,
+    bslz4_h5z_filter,
+};
+
 void plugin_open(const char *filename, int info[1024], int *error_flag) {
   int retval = 0;
   *error_flag = 0;
@@ -104,6 +122,10 @@ void plugin_open(const char *filename, int info[1024], int *error_flag) {
 
   if (H5dont_atexit() < 0) {
     ERROR_JUMP(-2, done, "Failed configuring HDF5 library behaviour");
+  }
+
+  if (register_bitshuffle_filter() < 0) {
+    ERROR_JUMP(-2, done, "Failed registering bitshuffle filter");
   }
 
   if (init_h5_error_handling() < 0) {
@@ -241,6 +263,64 @@ void plugin_close(int *error_flag) {
   if (H5close() < 0) {
     *error_flag = -1;
   }
+}
+
+static size_t bslz4_h5z_filter(unsigned int flags, size_t cd_nelmts,
+                               const unsigned int cd_values[],
+                               size_t nbytes, size_t *buf_size,
+                               void **buf) {
+  size_t new_size = 0;
+  void *new_buf = NULL;
+  void *old_buf = *buf;
+
+  if (!(flags & H5Z_FLAG_REVERSE)) {
+    /* This plugin only supports decode/read direction. */
+    return nbytes;
+  }
+
+  if (cd_nelmts != BS_H5_N_PARAMS) {
+    return 0;
+  }
+
+  if (nbytes < 8) {
+    return 0;
+  }
+
+  const unsigned char *in_buf = (const unsigned char *)old_buf;
+  uint64_t uncompressed_size = 0;
+  for (int i = 0; i < 8; ++i) {
+    uncompressed_size = (uncompressed_size << 8) | in_buf[i];
+  }
+  new_size = (size_t)uncompressed_size;
+
+  new_buf = malloc(new_size);
+  if (!new_buf) {
+    return 0;
+  }
+
+  if (bslz4_decompress(cd_values, nbytes, old_buf, new_size, new_buf) < 0) {
+    free(new_buf);
+    return 0;
+  }
+
+  free(old_buf);
+  *buf = new_buf;
+  *buf_size = new_size;
+  return new_size;
+}
+
+static int register_bitshuffle_filter(void) {
+  htri_t available = H5Zfilter_avail(BS_H5_FILTER_ID);
+  if (available < 0) {
+    return -1;
+  }
+  if (available > 0) {
+    return 0;
+  }
+  if (H5Zregister(&bslz4_h5z_class) < 0) {
+    return -1;
+  }
+  return 0;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Change the order of priority for where to look for data in hdf5 files, to prefer the virtual dataset under the "data" key instead of the linked image files under the data_###### key. 

This is needed because the virtual dataset is more likely to be pointing to the correct data now that data acquisition are able to collect multiple virtual data collections in a single collection (e.g. for multi-sample pins). Data is collected in this way so that the detector only needs to be armed once per pin, while collecting multiple samples. In these types of data collections, the master.h5 file links to all images taken in the full collection with the virtual dataset mapping to the correct images for the given sample. In this scenario, looking for data using the dectris-eiger strategy (i.e. in data_000001), the durin plugin will always find the images corresponding to the first sample, regardless of which sample it is supposed to be processing.

In order to read from the virtual dataset, the bitshuffle library is required for data filtering. The bitshuffle code was already being built in the durin plugin, however, it was not usable because it was not being registered. This PR registers bitshuffle library into the plugin so that external bitshuffle libraries are not required for the durin plugin to work. 