### PR TITLE
Update hdf5 version to 2.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,12 @@ if (BUILD_HDF5)
     include(FetchContent)
     FetchContent_Declare(
         hdf5
-        URL https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_12_1.tar.gz
-        URL_HASH SHA256=e6dde173c2d243551922d23a0387a79961205b018502e6a742acb30b61bc2d5f
+        URL https://github.com/HDFGroup/hdf5/releases/download/2.1.1/hdf5-2.1.1.tar.gz
+        URL_HASH SHA256=efff93b5a904d66e8f626d7da60b5eedc9faf544be27dbabbaa87967b8ad798b
     )
     # To get what we want, this includes overriding settings
     set(HDF5_EXTERNALLY_CONFIGURED ON)
-    set(ALLOW_UNSUPPORTED ON CACHE BOOL "Allow HL and threadsafe" FORCE)
+    set(HDF5_ALLOW_UNSUPPORTED ON CACHE BOOL "Allow HL and threadsafe" FORCE)
     set(BUILD_TESTING OFF CACHE BOOL "Build HDF5 Unit Testing")
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build Shared Libraries")
     set(HDF5_BUILD_CPP_LIB OFF CACHE BOOL "Build HDF5 C++ Library")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,6 @@ add_library(durin-objects OBJECT src/file.c src/err.c src/filters.c )
 target_link_libraries(durin-objects PUBLIC HDF5::HDF5 )
 target_link_libraries(durin-objects PRIVATE bslz4 )
 set_property(TARGET durin-objects PROPERTY POSITION_INDEPENDENT_CODE ON)
-# Even if using HDF5 1.12, we want the 1.10 API
-target_compile_definitions(durin-objects PUBLIC H5_USE_110_API)
 
 ###############################################################################
 # durin-plugin

--- a/src/file.c
+++ b/src/file.c
@@ -927,7 +927,7 @@ int get_detector_info(const hid_t fid, struct ds_desc_t **desc) {
   herr_t err = 0;
   struct det_visit_objects_t objects = {0};
   err =
-      H5Ovisit(fid, H5_INDEX_NAME, H5_ITER_INC, &det_visit_callback, &objects);
+      H5Ovisit(fid, H5_INDEX_NAME, H5_ITER_INC, &det_visit_callback, &objects, H5O_INFO_BASIC);
   if (err < 0) {
     clear_det_visit_objects(&objects);
     ERROR_JUMP(-1, done, "Error during H5Ovisit callback");


### PR DESCRIPTION
Use HDF5 version 2.1.1 in the plugin build, including the default API.

Downloads HDF5 2.1.1 and no longer specifies using an older API version. Update env variable name to  `HDF5_ALLOW_UNSUPPORTED` and add the required field argument to H5OVISIT macro. Using  `H5O_INFO_BASIC` as the field argument as this is the most lightweight option and this feature is not being used.